### PR TITLE
Create dynamic hostname when using deploy to bluemix button

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -22,10 +22,10 @@ stages:
         script: |-
             #!/bin/bash
             cf create-service iotf-service iotf-service-free iotp-for-conveyor
-            cf push conveyorbelt-iotp --no-start
-            cf bind-service conveyorbelt-iotp iotp-for-conveyor
-            cf restage conveyorbelt-iotp
-            cf start conveyorbelt-iotp
+            cf push ${CF_APP} --no-start
+            cf bind-service ${CF_APP} iotp-for-conveyor
+            cf restage ${CF_APP}
+            cf start ${CF_APP}
         target:
           organization: ${CF_ORGANIZATION}
           space: ${CF_SPACE}


### PR DESCRIPTION
The current model of bluemix button will always create the app with the hostname **conveyorbelt-iotp**.  In order to avoid repeated hostname, we need to use ${CF_APP}.